### PR TITLE
minor authentication fixes

### DIFF
--- a/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.SiteProvisioning/Components/MSGraphAPISettings.cs
+++ b/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.SiteProvisioning/Components/MSGraphAPISettings.cs
@@ -8,9 +8,9 @@ namespace OfficeDevPnP.PartnerPack.SiteProvisioning.Components
 {
     public static class MSGraphAPISettings
     {
-        public static string ClientId = ConfigurationManager.AppSettings["ida:ClientId"];
-        public static string ClientSecret = ConfigurationManager.AppSettings["ida:ClientSecret"];
-        public static string AADInstance = ConfigurationManager.AppSettings["ida:AADInstance"];
+        public static string ClientId { get { return ConfigurationManager.AppSettings["ida:ClientId"]; } }
+        public static string ClientSecret { get { return ConfigurationManager.AppSettings["ida:ClientSecret"]; } }
+        public static string AADInstance { get { return ConfigurationManager.AppSettings["ida:AADInstance"]; } }
         public static string MicrosoftGraphResourceId = "https://graph.microsoft.com";
     }
 }

--- a/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.SiteProvisioning/Web.config
+++ b/OfficeDevPnP.PartnerPack.SiteProvisioning/OfficeDevPnP.PartnerPack.SiteProvisioning/Web.config
@@ -53,6 +53,7 @@
     </ProvisioningJobs>
   </PnPPartnerPackConfiguration>
   <system.web>
+    <authentication mode="None" />
     <customErrors mode="On" />
     <compilation debug="true" targetFramework="4.5.2" />
     <httpRuntime targetFramework="4.5.2" />


### PR DESCRIPTION
included some minor authentication fixes that I needed when I was debugging on my local SharePoint dev VM.  These fixes enabled the Partner Pack website to properly authenticate my user to Azure AD instead of assuming I was already authorized via Active Directory on my local machine.